### PR TITLE
Fixing Check_Type bug and forcing 2-argument mode for all Hadoop::DFS::FileSystem.delete calls

### DIFF
--- a/ext/hdfs/hdfs.c
+++ b/ext/hdfs/hdfs.c
@@ -888,7 +888,7 @@ void Init_hdfs() {
   rb_define_method(c_file_system, "chgrp", HDFS_File_System_chgrp, 2);
   rb_define_method(c_file_system, "chmod", HDFS_File_System_chmod, 2);
   rb_define_method(c_file_system, "chown", HDFS_File_System_chown, 2);
-  rb_define_method(c_file_system, "copy", HDFS_File_System_copy, 2);
+  rb_define_method(c_file_system, "copy", HDFS_File_System_copy, 3);
   rb_define_method(c_file_system, "capacity", HDFS_File_System_capacity, 0);
   rb_define_method(c_file_system, "default_block_size",
       HDFS_File_System_default_block_size, 0);


### PR DESCRIPTION
This pull request addresses a bug in the typechecking bug via what appears to be the idiomatic Ruby boolean detection method, comparing the value to the statically-defined Qtrue typedef; this has been tested to work successfully.

Additionally, as we are not yet using variable arguments, we are forcing two arguments to Hadoop::DFS::FileSystem.delete and three arguments to Hadoop::DFS::FileSystem.copy for proper operation.

Let me know what you think, and thanks for the consideration!
