### PR TITLE
if a needed library cannot be found, the build should raise an error

### DIFF
--- a/ext/hdfs/extconf.rb
+++ b/ext/hdfs/extconf.rb
@@ -42,7 +42,7 @@ end
 
 dir_config 'hdfs'
 ['jvm', 'hdfs'].each do |lib|
-  find_library lib, nil, ENV['JAVA_LIB']
+  raise "Cannot find lib#{lib}" unless find_library lib, nil, ENV['JAVA_LIB']
 end
 
 have_library    'c', 'main'


### PR DESCRIPTION
The gem was building and installing, and then aborting my program at runtime, because libhdfs was not found. It only needed a `--with-hdfs-dir` added to the build line, but it took way too much time to determine that.
